### PR TITLE
Improve contrast for important text

### DIFF
--- a/_sass/foundation/_settings.scss
+++ b/_sass/foundation/_settings.scss
@@ -55,7 +55,7 @@
 $rem-base: 14px;
 
 // Allows the use of rem-calc() or lower-bound() in your settings
-@import "foundation/functions";
+@import 'foundation/functions';
 
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
@@ -89,7 +89,8 @@ $row-width: rem-calc(1120);
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // We use these to define default font stacks
-$font-family-sans-serif: Raleway, "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+$font-family-sans-serif: Raleway, 'Helvetica Neue', Helvetica, Roboto, Arial,
+  sans-serif;
 // $font-family-serif: Georgia, Cambria, "Times New Roman", Times, serif;
 // $font-family-monospace: Consolas, "Liberation Mono", Courier, monospace;
 
@@ -97,7 +98,7 @@ $font-family-sans-serif: Raleway, "Helvetica Neue", Helvetica, Roboto, Arial, sa
 // $font-weight-normal: normal;
 // $font-weight-bold: bold;
 
-$white       : #FFFFFF;
+$white: #ffffff;
 // $ghost       : #FAFAFA;
 // $snow        : #F9F9F9;
 // $vapor       : #F6F6F6;
@@ -114,11 +115,11 @@ $white       : #FFFFFF;
 // $charcoal    : #555555;
 // $tuatara     : #444444;
 // $oil         : #333333;
-$jet         : #999;
+$jet: #999;
 // $black       : #000000;
 
 // We use these as default colors throughout
-$primary-color: #F9CE06;
+$primary-color: #f9ce06;
 // $secondary-color: #e7e7e7;
 // $alert-color: #f04124;
 // $success-color: #43AC6A;
@@ -159,7 +160,7 @@ $medium-range: (50em, 64em);
 // $xlarge-range: (90.063em, 120em);
 // $xxlarge-range: (120.063em, 99999999em);
 
-$screen: "only screen";
+$screen: 'only screen';
 
 // $landscape: "#{$screen} and (orientation: landscape)";
 // $portrait: "#{$screen} and (orientation: portrait)";
@@ -563,7 +564,6 @@ $button-border-color: $primary-color;
 // Default radius for dropdown.
 // $f-dropdown-radius: $global-radius;
 
-
 // 09. Dropdown Buttons
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -644,7 +644,7 @@ $input-focus-border-color: scale-color($white, $lightness: -30%);
 // $input-border-radius: $global-radius;
 // $input-disabled-bg: $gainsboro;
 // $input-disabled-cursor: $cursor-default-value;
-$input-box-shadow: inset 0 1px 2px rgba(0,0,0,0);
+$input-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0);
 // $input-include-glowing-effect: true;
 
 // We use these to style the fieldset border and spacing.
@@ -688,7 +688,6 @@ $glowing-effect-color: none;
 // Select variables
 // $select-bg-color: $ghost;
 // $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%);
-
 
 // 12. Icon Bar
 // - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -829,7 +828,6 @@ $glowing-effect-color: none;
 // Off Canvas Divider Styles
 // $tabbar-left-section-border: solid 1px scale-color($tabbar-bg, $lightness: -50%);
 // $tabbar-right-section-border: $tabbar-left-section-border;
-
 
 // Off Canvas Tab Bar Headers
 // $tabbar-header-color: $white;
@@ -1016,7 +1014,6 @@ $glowing-effect-color: none;
 // $price-money-weight: $font-weight-normal;
 // $price-money-size: rem-calc(32);
 // $price-money-font-family: $body-font-family;
-
 
 // We use these to control the description styles
 // $price-bg: $white;
@@ -1233,7 +1230,6 @@ $glowing-effect-color: none;
 // $sub-nav-border-radius: 3px;
 // $sub-nav-font-color-hover: scale-color($sub-nav-font-color, $lightness: -25%);
 
-
 // We use these to control the active item styles
 
 // $sub-nav-active-font-weight: $font-weight-normal;
@@ -1311,7 +1307,6 @@ $glowing-effect-color: none;
 // $table-layout: auto;
 // $table-display: table-cell;
 // $table-margin-bottom: rem-calc(20);
-
 
 // 31. Tabs
 // - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1393,10 +1388,10 @@ $topbar-height: rem-calc(100);
 // $topbar-title-font-size: rem-calc(17);
 
 // Set the link colors and styles for top-level nav
-$topbar-link-color: #999;
-$topbar-link-color-hover: #888;
-$topbar-link-color-active: #888;
-$topbar-link-color-active-hover: #888;
+$topbar-link-color: #545454;
+$topbar-link-color-hover: #545454;
+$topbar-link-color-active: #545454;
+$topbar-link-color-active-hover: #545454;
 // $topbar-link-weight: $font-weight-normal;
 $topbar-link-font-size: rem-calc(14);
 // $topbar-link-hover-lightness: -10%; // Darken by 10%
@@ -1421,7 +1416,7 @@ $topbar-dropdown-link-color-hover: #fff;
 $topbar-dropdown-link-bg-hover: #444;
 // $topbar-dropdown-link-weight: $font-weight-normal;
 // $topbar-dropdown-toggle-size: 5px;
-$topbar-dropdown-toggle-color: #999;
+$topbar-dropdown-toggle-color: #545454;
 // $topbar-dropdown-toggle-alpha: 0.4;
 
 // $topbar-dropdown-label-color: $monsoon;
@@ -1434,8 +1429,8 @@ $topbar-dropdown-toggle-color: #999;
 // $topbar-menu-link-transform: uppercase;
 // $topbar-menu-link-font-size: rem-calc(13);
 // $topbar-menu-link-weight: $font-weight-bold;
-$topbar-menu-link-color: #999;
-$topbar-menu-icon-color: #999;
+$topbar-menu-link-color: #545454;
+$topbar-menu-icon-color: #545454;
 // $topbar-menu-link-color-toggled: $jumbo;
 // $topbar-menu-icon-color-toggled: $jumbo;
 // $topbar-menu-icon-position: $opposite-direction; // Change to $default-float for a left menu icon
@@ -1444,8 +1439,7 @@ $topbar-menu-icon-color: #999;
 // $topbar-transition-speed: 300ms;
 // Using rem-calc for the below breakpoint causes issues with top bar
 // $topbar-breakpoint: #{lower-bound($medium-range)}; // Change to 9999px for always mobile layout
-$topbar-media-query: "#{$screen} and (min-width:960px)";
-
+$topbar-media-query: '#{$screen} and (min-width:960px)';
 
 // Top-bar input styles
 // $topbar-input-height: rem-calc(28);

--- a/css/home.css
+++ b/css/home.css
@@ -7,7 +7,7 @@
   position: absolute;
   height: 100%;
   width: 100%;
-  background-color: rgba(0,0,0,0.2);
+  background-color: rgba(0, 0, 0, 0.2);
   top: 0;
   z-index: -1;
 }

--- a/css/indrel.css
+++ b/css/indrel.css
@@ -1,12 +1,14 @@
 .section > .modClients {
-  width: 100%
+  width: 100%;
 }
 
 .client-image {
   padding: 15px;
 }
 
-table tr td, table tr th {
+table tr td,
+table tr th {
   text-align: center;
   padding: 15px;
+  color: #545454;
 }

--- a/css/theme/main.css
+++ b/css/theme/main.css
@@ -608,14 +608,14 @@
 }
 /*some basic settings */
 a {
-  color: #F9CE06;
+  color: #0057A8;
   -moz-transition-duration: 0.3s;
   -o-transition-duration: 0.3s;
   -webkit-transition-duration: 0.3s;
   transition-duration: 0.3s;
 }
 a:hover {
-  color: #999;
+  color: #575757;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -779,12 +779,12 @@ ul.shortcode-list i {
   text-transform: uppercase;
   letter-spacing: 1px;
   color: #fff;
-  background: #F9CE06;
-  border: 2px solid #F9CE06;
+  background: #0057A8;
+  border: 2px solid #0057A8;
 }
 
 .button:hover {
-  background-color: rgba(249, 206, 6, 0.8);
+  background-color: rgba(0, 87, 168, 0.8);
 }
 
 .button.boxed {
@@ -1111,7 +1111,7 @@ form input.error, form textarea.error {
   line-height: 1.8em;
 }
 .links a {
-  color: #999;
+  color: #575757;
 }
 .links a:hover {
   color: #333;
@@ -1120,7 +1120,7 @@ form input.error, form textarea.error {
 /*Footer */
 #footer {
   background: #222;
-  color: #999;
+  color: #ADADAD;
 }
 #footer h1 {
   margin-bottom: 25px;
@@ -1136,7 +1136,7 @@ form input.error, form textarea.error {
   line-height: 1.875rem;
 }
 #footer ul a {
-  color: #999;
+  color: #ADADAD;
 }
 #footer ul a:hover {
   color: #eee;
@@ -3038,6 +3038,7 @@ form input.error, form textarea.error {
 }
 body {
   overflow-y: scroll;
+  color: #575757;
 }
 
 .modMasonryGallery .gallery-nav {


### PR DESCRIPTION
Improved contrast of text for accessibility reasons. WebAIM recommends a contrast of at least 7:1 between text and background color. I darkened many of the lighter grays on white backgrounds to meet this contrast without changing the theme too much. I also lightened the lighter grays on dark gray backgrounds. I changed the background of the button and anchor tags from yellow to blue since there was white text on top. Overall, the website's text looks more "clear" and there's less strain to try to read. I've attached some images of before and after to see what I mean.

Before:
![Screenshot from 2022-04-01 15-17-59](https://user-images.githubusercontent.com/63762580/161353243-f6ab196a-0b34-48f9-a9e7-ab424efca47f.png)
After:
![Screenshot from 2022-04-01 15-18-24](https://user-images.githubusercontent.com/63762580/161353253-533c5db2-aa21-4968-9124-3c30e1eb8149.png)

Before:
![Screenshot from 2022-04-01 16-13-35](https://user-images.githubusercontent.com/63762580/161353263-ec69fd3c-c59b-4a94-b781-2f5652432802.png)
After:
![Screenshot from 2022-04-01 16-13-13](https://user-images.githubusercontent.com/63762580/161353303-f6516bfe-4847-45ff-81c4-0e66926b7db0.png)



