### PR TITLE
fix topbar graphical bug

### DIFF
--- a/_sass/foundation/_settings.scss
+++ b/_sass/foundation/_settings.scss
@@ -1439,7 +1439,7 @@ $topbar-menu-icon-color: #545454;
 // $topbar-transition-speed: 300ms;
 // Using rem-calc for the below breakpoint causes issues with top bar
 // $topbar-breakpoint: #{lower-bound($medium-range)}; // Change to 9999px for always mobile layout
-$topbar-media-query: '#{$screen} and (min-width:960px)';
+$topbar-media-query: '#{$screen} and (min-width:1200px)';
 
 // Top-bar input styles
 // $topbar-input-height: rem-calc(28);

--- a/css/theme/main.css
+++ b/css/theme/main.css
@@ -3616,7 +3616,7 @@ body {
 .modTestimonials.simple .slick-slider {
   margin-bottom: 10px;
 }
-@media only screen and (max-width: 60em) {
+@media only screen and (max-width: 1200px) {
   .modTeamMember .overlay {
     opacity: 1;
     background-color: rgba(255, 255, 255, 0.8);
@@ -3848,3 +3848,4 @@ body {
 
 .title {
   text-shadow: 0px 0px 15px black;
+}


### PR DESCRIPTION
Addresses the `topbar` graphical bug mentioned in the issue below. Achieves this by increasing the `max-width` property from `960px` to `1200px`, which is necessary because of the new "blog" entry in the topbar.

Fixes #64

![out](https://user-images.githubusercontent.com/16968917/200095683-646f5da5-e143-41be-9d25-3e1d1c189bad.gif)